### PR TITLE
don't convert buffer to string

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "concat-stream": "^1.5.1",
     "dauria": "^1.1.3",
     "debug": "^2.2.0",
-    "from2-string": "^1.1.0",
+    "from2": "^2.1.1",
     "mime-types": "^2.1.10",
     "uberproto": "^1.2.0"
   },

--- a/src/util.js
+++ b/src/util.js
@@ -1,8 +1,22 @@
 import crypto from 'crypto';
-import fromString from 'from2-string';
+import from from 'from2';
 
+// TODO publish to npm as `from2-buffer`
+// create a stream from a buffer
+// buffer -> stream
 export function fromBuffer (buffer) {
-  return fromString(buffer.toString());
+  //assert.ok(Buffer.isBuffer(buffer))
+
+  return from(function (size, next) {
+    if (buffer.length <= 0) {
+      return this.push(null);
+    }
+
+    const chunk = buffer.slice(0, size);
+    buffer = buffer.slice(size);
+
+    next(null, chunk);
+  });
 }
 
 export function bufferToHash (buffer) {


### PR DESCRIPTION
was causing binary files to be mangled, since they were being converted into utf8 strings.