### PR TITLE
Add S3 Params when uploading files.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ class Service {
     fromBuffer(buffer)
     .pipe(this.Model.createWriteStream({
       key: id,
-      params: params.query
+      params: params.s3
     }, function () {
       cb(null, {
         [this.id]: id,

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,8 @@ class Service {
 
     fromBuffer(buffer)
     .pipe(this.Model.createWriteStream({
-      key: id
+      key: id,
+      params: params.query
     }, function () {
       cb(null, {
         [this.id]: id,


### PR DESCRIPTION
When setting S3 params you can, for example, set the permissions for an uploaded file. This uses the `query` object that is inside the request's `params`.

Fixes #7 