### PR TITLE
Wrong field name for custom id in create method

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Also install a [`abstract-blob-store` compatible module](https://github.com/maxo
 
 where input `body` is an object with key `uri` pointing to [data URI](https://en.wikipedia.org/wiki/Data_URI_scheme) of the blob.
 
-Optionally, you can specify in the `body` the blob `key` which can be the file
+Optionally, you can specify in the `body` the blob `id` which can be the file
 path where you want to store the file, otherwise it would default to
 `${hash(content)}.${extension(contentType)}`.
 


### PR DESCRIPTION
The **body.key** field is ignored, only **id** and **uri** are actually used:

    let { id, uri } = body;
